### PR TITLE
Add support for engine options and JSON literal in options.data

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,14 +45,14 @@ A path to the data (JSON) file that will be merged with the templates.
 ### Usage Examples
 
 #### Options
-In this example, the data (JSON) file is specified in the options, and the velocity templates (that consume the data) & output folder are specified in the task.
+In this example, the data (JSON file or JSON Object) is specified in the options, and the velocity templates (that consume the data) & output folder are specified in the task.
 The example below is in the grunt format, of dest: [src files], but any standard grunt format can be used.
 
 ```js
 grunt.initConfig({
   velocity: {
      options: {
-        data: 'path/to/data.json'
+        data: 'path/to/data.json' // alternately {}
      },
      files: {
       'my/output_folder/': ['src/velocity-templates/**/*.vm']

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "grunt-velocity-parser",
   "description": "Grunt plugin to run velocity templates through a velocity engine in an unopinionated way",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "homepage": "https://github.com/stephenwil/grunt-velocity",
   "author": {
     "name": "Stephen Wilson",
@@ -41,6 +41,7 @@
     "velocity templates"
   ],
   "dependencies": {
+    "underscore": "^1.8.3",
     "velocity": "^0.7.1"
   }
 }

--- a/tasks/velocity.js
+++ b/tasks/velocity.js
@@ -9,7 +9,7 @@
 'use strict';
 
 module.exports = function(grunt) {
-
+  var _ = require('underscore');
   // Please see the Grunt documentation for more information regarding task
   // creation: http://gruntjs.com/creating-tasks
 
@@ -21,8 +21,10 @@ module.exports = function(grunt) {
 
     // Iterate over all specified file groups.
     this.files.forEach(function(f) {
-      
-      
+
+      var data = options.data;
+      delete options.data;
+
       if (options.data && !grunt.file.exists(options.data)) {
         grunt.log.warn('Data file"' + options.data + '" not found.');
         return false;
@@ -30,34 +32,39 @@ module.exports = function(grunt) {
 
       f.src.forEach(function(file) {
         grunt.log.ok('Processing ' + file);
-        
+
         if (!grunt.file.exists(file)) {
           grunt.log.warn('Source file "' + file + '" not found.');
           return false;
         }
-        
-        parseVelocity(file, f.dest, Engine, options.data);
+
+        parseVelocity(file, f.dest, Engine, data, options);
         count++;
       });
-      
+
       grunt.log.ok('Parsed ' + count + ' file(s)');
     });
-    
-    function parseVelocity(srcFile, dest, Engine, dataFile) {
 
+    function parseVelocity(srcFile, dest, Engine, dataFile, options) {
+      var data;
       // read the data file
-      var data = grunt.file.readJSON(dataFile, {encoding: 'utf8'});
-      
+      if (typeof dataFile === "string") {
+        data = grunt.file.readJSON(dataFile, {encoding: 'utf8'});
+      } else {
+        // data object passed in
+        data = dataFile;
+      }
+
       // read the src file
       var src = grunt.file.read(srcFile);
-     
-      var engine = new Engine({
+
+      var engine = new Engine(_.extend(options, {
         template: src
-      });
+      }));
       var output = engine.render(data);
 
       // Write the destination file.
-      grunt.file.write(dest + srcFile.replace('.vm','.html'), output);
+      grunt.file.write(dest + srcFile.replace(/.*\//, '').replace('.vm',''), output);
 
 
     }


### PR DESCRIPTION
This also removes the default replacement of .vm/.html to just strip the .vm (so you can define the files as index.html.vm and get index.html).
